### PR TITLE
Use tf.shape for graph mode support

### DIFF
--- a/distributed_embeddings/python/layers/dist_model_parallel.py
+++ b/distributed_embeddings/python/layers/dist_model_parallel.py
@@ -395,9 +395,9 @@ class DistributedEmbedding(tf.keras.layers.Layer):
         local_shapes, local_splits, global_splits, flat_inputs = [], [], [], []
         for rank_input_ids in self.strategy.input_ids_list:
           rank_inputs = [inputs[index] for index in rank_input_ids]
-          local_shapes.append([inp.shape for inp in rank_inputs])
+          local_shapes.append([tf.shape(inp) for inp in rank_inputs])
           rank_inputs = [tf.reshape(inp, [-1]) for inp in rank_inputs]
-          local_splits.append([inp.shape[0] for inp in rank_inputs])
+          local_splits.append([tf.shape(inp)[0] for inp in rank_inputs])
           global_splits.append(sum(local_splits[-1]))
           flat_inputs += rank_inputs
         inputs = tf.concat(flat_inputs, 0)
@@ -405,7 +405,7 @@ class DistributedEmbedding(tf.keras.layers.Layer):
         inputs = tf.reshape(inputs, [self.world_size, -1])
         inputs = tf.split(inputs, local_splits[self.rank], 1)
         inputs = [
-            tf.reshape(inp, [self.world_size * shape[0]] + shape[1:])
+            tf.reshape(inp, tf.concat([[self.world_size * shape[0]], shape[1:]], 0))
             for inp, shape in zip(inputs, local_shapes[self.rank])
         ]
       else:

--- a/distributed_embeddings/python/layers/dist_model_parallel.py
+++ b/distributed_embeddings/python/layers/dist_model_parallel.py
@@ -395,9 +395,13 @@ class DistributedEmbedding(tf.keras.layers.Layer):
         local_shapes, local_splits, global_splits, flat_inputs = [], [], [], []
         for rank_input_ids in self.strategy.input_ids_list:
           rank_inputs = [inputs[index] for index in rank_input_ids]
-          local_shapes.append([tf.shape(inp) for inp in rank_inputs])
+          local_shapes.append(
+            [tf.shape(inp) if None in inp.shape else inp.shape for inp in rank_inputs]
+          )
           rank_inputs = [tf.reshape(inp, [-1]) for inp in rank_inputs]
-          local_splits.append([tf.shape(inp)[0] for inp in rank_inputs])
+          local_splits.append(
+            [tf.shape(inp)[0] if inp.shape[0] is None else inp.shape[0] for inp in rank_inputs]
+          )
           global_splits.append(sum(local_splits[-1]))
           flat_inputs += rank_inputs
         inputs = tf.concat(flat_inputs, 0)

--- a/tests/dist_model_parallel_test.py
+++ b/tests/dist_model_parallel_test.py
@@ -274,7 +274,7 @@ class DistributedEmbeddingTest(keras_parameterized.TestCase):
 
     dp_inputs, _ = self.gen_inputs(table_sizes)
     self.run_and_test(ref_model, dp_inputs, test_model, dp_inputs)
-    for tables in test_model.dist_embeddings.strategy.table_ids_list:
+    for tables in test_model.dist_embeddings.strategy.table_ids:
       self.assertEqual(len(tables), len(set(tables)))
 
   def test_column_slice_threshold(self):


### PR DESCRIPTION
## Why

With custom layers/models in graph mode, it seems to have trouble inferring shapes because `.shape` is used in `call()` instead of `tf.shape()`, and I'm running into issues such as:
```
[1,0]<stdout>:E                               TypeError: Exception encountered when calling layer "distributed_embedding" "                 f"(type DistributedEmbedding).
[1,0]<stdout>:E
[1,0]<stdout>:E                               in user code:
[1,0]<stdout>:E
[1,0]<stdout>:E                                   File "/usr/local/lib/python3.8/dist-packages/distributed_embeddings/python/layers/dist_model_parallel.py", line 503, in call  *
[1,0]<stdout>:E                                       outputs = self._call_base(inputs)
[1,0]<stdout>:E                                   File "/usr/local/lib/python3.8/dist-packages/distributed_embeddings/python/layers/dist_model_parallel.py", line 279, in _call_base  *
[1,0]<stdout>:E                                       global_splits.append(sum(local_splits[-1]))
[1,0]<stdout>:E
[1,0]<stdout>:E                                   TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
[1,0]<stdout>:E
[1,0]<stdout>:E
[1,0]<stdout>:E                               Call arguments received by layer "distributed_embedding" "                 f"(type DistributedEmbedding):
[1,0]<stdout>:E                                 • inputs=['tf.Tensor(shape=(None, None), dtype=int64)', 'tf.Tensor(shape=(None, None), dtype=int64)']
```
We've run into this error while trying to integrate distributed-embeddings into Merlin Models (https://github.com/NVIDIA-Merlin/models/pull/974).

From [Tensorflow docs](https://www.tensorflow.org/api_docs/python/tf/shape):
> [tf.shape](https://www.tensorflow.org/api_docs/python/tf/shape) and [Tensor.shape](https://www.tensorflow.org/api_docs/python/tf/Tensor#shape) should be identical in eager mode. Within [tf.function](https://www.tensorflow.org/api_docs/python/tf/function) or within a [compat.v1](https://www.tensorflow.org/api_docs/python/tf/compat/v1) context, not all dimensions may be known until execution time. Hence, when defining custom layers and models for graph mode, prefer the dynamic [tf.shape(x)](https://www.tensorflow.org/api_docs/python/tf/shape) over the static x.shape.

This PR proposes to replace `.shape` with `tf.shape()`. According to the doc quoted above, it seems that `tf.shape()` has advantages because it should behave the same as `.shape` in eager mode and will also work correctly in graph mode. With the changes in this PR, I've managed to make the custom model work without errors.

## Testing
Manually ran
```
python distributed_embeddings/python/layers/dist_model_parallel_test.py
python tests/dist_model_parallel_test.py
```
This PR includes a variable name change that makes the tests in `python tests/dist_model_parallel_test.py` pass.